### PR TITLE
fix output length limits for comments

### DIFF
--- a/src/assignment_codeval/evaluate.py
+++ b/src/assignment_codeval/evaluate.py
@@ -683,10 +683,9 @@ def check_output_file(output_file):
     Returns:
         None
     """
-    output_length(os.path.getsize(output_file)) 
     with open(output_file, "r") as infile:
         output_lines = infile.readlines()
-        
+
     with open(get_testing_path("expectedoutput"), "a") as outfile:
         outfile.writelines(output_lines)
 

--- a/src/assignment_codeval/submissions.py
+++ b/src/assignment_codeval/submissions.py
@@ -272,10 +272,10 @@ def upload_submission_comments(submissions_dir, codeval_prefix, delete):
                 if submission:
                     write_html_file(dirpath)
                     file_id = upload_file_for_comment(canvas, course.id, assignment.id, student_id, f"{dirpath}/results.html")
-                    with open(f"{dirpath}/comments.txt", "r") as fd:
+                    with open(f"{dirpath}/comments.txt", "rb") as fd:
                         # canvas max is 65000, so 32K will keep us well below that
-                        comment = fd.read(32*1024)
-                        comment = comment.replace("\0", "\\0").strip().replace("<", "&lt;")
+                        comment_bytes = fd.read(32*1024).replace(b'\0', b'\\0').replace(b'<', b'&lt;')
+                        comment = comment_bytes[:32*1024].decode('utf-8', errors='ignore')
                     subs_file = f"{dirpath}/SUBSTITUTIONS.txt"
                     if os.path.isfile(subs_file):
                         substitutions = _parse_substitutions_file(subs_file)

--- a/src/assignment_codeval/submissions.py
+++ b/src/assignment_codeval/submissions.py
@@ -273,7 +273,8 @@ def upload_submission_comments(submissions_dir, codeval_prefix, delete):
                     write_html_file(dirpath)
                     file_id = upload_file_for_comment(canvas, course.id, assignment.id, student_id, f"{dirpath}/results.html")
                     with open(f"{dirpath}/comments.txt", "r") as fd:
-                        comment = fd.read(4096)
+                        # canvas max is 65000, so 32K will keep us well below that
+                        comment = fd.read(32*1024)
                         comment = comment.replace("\0", "\\0").strip().replace("<", "&lt;")
                     subs_file = f"{dirpath}/SUBSTITUTIONS.txt"
                     if os.path.isfile(subs_file):


### PR DESCRIPTION
- canvas has a 65000 byte limit for comments. let's be generouse with the comment.txt limit since we are doing OLEN limits in run-evaluation
- remove the output limit override with OF. some OF files are very small, and make mess up future outputs due to a small limit